### PR TITLE
German and Spanish plagin names were fixed

### DIFF
--- a/LanguageFiles/de-DE/AutoCAD.xml
+++ b/LanguageFiles/de-DE/AutoCAD.xml
@@ -25,7 +25,7 @@
     <e9>Unbekannter Validierungsmodus</e9>
   </mpTableSort>
   <mpMultiOffset
-    LocalName="MultiOffset"
+    LocalName="Multi-Offset"
     Description="Durchführung mehrerer Verschiebungen in einem Vorgang">
     <h1>Geben Sie die Offsets ein:</h1>
     <hint1>Zulässige Zeichen:

--- a/LanguageFiles/es-ES/AutoCAD.xml
+++ b/LanguageFiles/es-ES/AutoCAD.xml
@@ -25,7 +25,7 @@
     <e9>Modo de validación desconocido</e9>
   </mpTableSort>
   <mpMultiOffset
-    LocalName="Desplazamiento múltiple"
+    LocalName="Multidesplazamiento"
     Description="Realización de varios desplazamientos en una sola operación">
     <h1>Introduzca los desplazamientos:</h1>
     <hint1>Caracteres permitidos:


### PR DESCRIPTION
Изменил испанское и немецкое наименования плагинов в соответствии с уже принятыми названиями для существующих мульти- плагинов. 